### PR TITLE
Output value 'ast' is now added 

### DIFF
--- a/solc/main.py
+++ b/solc/main.py
@@ -66,9 +66,11 @@ def _parse_compiler_output(stdoutdata):
         return {}
 
     contracts = output['contracts']
+    sources = output['sources']
 
-    for _, data in contracts.items():
+    for source, data in contracts.items():
         data['abi'] = json.loads(data['abi'])
+        data['ast'] = sources[source.split(':')[0]]['AST']
 
     return contracts
 


### PR DESCRIPTION
### What was wrong?

Refer to: https://github.com/ethereum/py-solc/issues/50

### How was it fixed?

AST of the whole source file is added to each contract's AST data.