### PR TITLE
Removed 'clone-bin' option that was deprecated in solc 0.5.0

### DIFF
--- a/solc/main.py
+++ b/solc/main.py
@@ -81,7 +81,6 @@ ALL_OUTPUT_VALUES = (
     "ast",
     "bin",
     "bin-runtime",
-    "clone-bin",
     "devdoc",
     "interface",
     "opcodes",

--- a/solc/wrapper.py
+++ b/solc/wrapper.py
@@ -39,7 +39,6 @@ def solc_wrapper(solc_binary=None,
                  opcodes=None,
                  bin=None,
                  bin_runtime=None,
-                 clone_bin=None,
                  abi=None,
                  interface=None,
                  hashes=None,
@@ -123,9 +122,6 @@ def solc_wrapper(solc_binary=None,
 
     if bin_runtime:
         command.append('--bin-runtime')
-
-    if clone_bin:
-        command.append('--clone-bin')
 
     if abi:
         command.append('--abi')


### PR DESCRIPTION
### What was wrong?
Compilation would fail due to 'clone-bin' option getting automatically passed to the compiler.

### How was it fixed?
Removed clone-bin option from wrapper and main modules.

This fixed it for me but tests are not passing. I have 0 experience with tox and my attempts at fixing it were making it worse. This is my first pull request and I understand it's an iterative process so hopefully I could get some guidance on how to make those tests pass. Any help is appreciated!

#### Cute Animal Picture
![charlieboy](https://user-images.githubusercontent.com/31577879/49762902-0124c300-fc80-11e8-9016-e1c5b8411e2c.jpg)